### PR TITLE
I've fixed the issue where the background image would move when you s…

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -27,9 +27,12 @@ body, html {
 /* Image */
 .bg-image {
   background: black center / cover no-repeat;
-  position: relative;
-  height: 100%;
-  width: 100%;
+  position: fixed; /* Changed from relative */
+  top: 0;
+  left: 0;
+  width: 100vw; /* Changed from 100% */
+  height: 100vh; /* Changed from 100% */
+  z-index: -1; /* Added */
   animation: kenburns 88s linear infinite;
 }
 


### PR DESCRIPTION
…wipe on mobile.

I changed the CSS for the `.bg-image` class to use `position: fixed` instead of `position: relative`. This ensures the background image remains static during swipe gestures to open/close the modal on mobile devices, improving your experience.

Specifically, I made the following changes to `.bg-image` in `static/css/style.css`:
- `position` changed to `fixed`
- `top` set to `0`
- `left` set to `0`
- `width` changed to `100vw`
- `height` changed to `100vh`
- `z-index` set to `-1`